### PR TITLE
fix: increase number of load incs in Mg DAMASK example

### DIFF
--- a/matflow/data/workflows/tension_DAMASK_Mg.yaml
+++ b/matflow/data/workflows/tension_DAMASK_Mg.yaml
@@ -19,7 +19,7 @@ tasks:
     inputs:
       load_case::uniaxial:
         total_time: 100
-        num_increments: 1000
+        num_increments: 1500
         direction: x
         target_def_grad_rate: 1.0e-3
         dump_frequency: 5


### PR DESCRIPTION
The existing load case (100 seconds at `Fdot = 1e-3`) over 1000 increments fails to converge (max cut backs reached) in 1000 increments with the latest DAMASK release (3.1.0). Increasing to 1500 increments speeds it up and fixes the issue.